### PR TITLE
Aws support env auth

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -196,7 +196,8 @@ func (p *AwsSSMTunnelsProvider) Configure(ctx context.Context, req provider.Conf
 			)
 			return
 		}
-	} else {
+	} else if data.AccessKey.ValueString() != "" && data.SecretKey.ValueString() != "" {
+		// Load AWS configuration using static credentials if specified
 		awsCfg, err = config.LoadDefaultConfig(ctx,
 			config.WithRegion(data.Region.ValueString()),
 			config.WithCredentialsProvider(
@@ -207,6 +208,20 @@ func (p *AwsSSMTunnelsProvider) Configure(ctx context.Context, req provider.Conf
 				),
 			),
 		)
+
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Failed to load AWS configuration",
+				fmt.Sprintf("Error: %s", err),
+			)
+			return
+		}
+	} else {
+		// Fallback to environment variables or SSO if no explicit configuration provided
+		awsCfg, err = config.LoadDefaultConfig(ctx,
+			config.WithRegion(data.Region.ValueString()),
+		)
+
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Failed to load AWS configuration",


### PR DESCRIPTION
For use-cases like using terraform provider with AWS SSO auth (and in some other cases) it's useful to be able to specify AWS credentials via env variables.

This PR adds using of default auth method (which utilises env vars) if there's no auth options specified in provider.

Related to https://github.com/ComplyCo/terraform-provider-aws-ssm-tunnels/issues/27